### PR TITLE
Moved server route to .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+frontend/.env

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# used whenever code is ran on client side
+NEXT_PUBLIC_SERVER_ROUTE="http://127.0.0.1:1337/"
+
+# used whenever code is ran on server side
+SERVER_ROUTE="http://127.0.0.1:1337/"

--- a/frontend/app/articles/[id]/page.tsx
+++ b/frontend/app/articles/[id]/page.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import styles from './styles.module.css';
+import 'dotenv/config'
 import ArticleContent from './ArticleContent';
 
 async function getArticle(articleId: string) {
 	const res = await fetch(
-		`http://localhost:1337/api/articles/${articleId}?populate=*`,
+		`${process.env.SERVER_ROUTE}api/articles/${articleId}?populate=*`,
 		{ cache: 'no-store' }
 	);
 	if (!res.ok) {

--- a/frontend/app/discover/CategorySection.tsx
+++ b/frontend/app/discover/CategorySection.tsx
@@ -2,10 +2,11 @@
 import React, { useEffect, useState } from "react";
 import styles from "./categorySection.module.css";
 import { BlogCard } from "@/components/blog-card/BlogCard";
+import 'dotenv/config'
 
 const getCategoryArticles = async (categoryId: any, pagination: number) => {
     const res = await fetch(
-        `http://localhost:1337/api/articles?filters[category][id][$eq]=${categoryId}&pagination[start]=0&pagination[limit]=${pagination}&pagination[withCount]=true&sort[0]=updatedAt:desc`,
+        `${process.env.NEXT_PUBLIC_SERVER_ROUTE}api/articles?filters[category][id][$eq]=${categoryId}&pagination[start]=0&pagination[limit]=${pagination}&pagination[withCount]=true&sort[0]=updatedAt:desc`,
         {
             cache: "no-store",
         }

--- a/frontend/app/discover/page.tsx
+++ b/frontend/app/discover/page.tsx
@@ -1,11 +1,12 @@
 import { BlogCard } from "@/components/blog-card/BlogCard";
 import React from "react";
+import 'dotenv/config'
 import styles from "./styles.module.css";
 import { CategorySection } from "./CategorySection";
 import SearchBar from "./SearchBar";
 
 async function getCategories() {
-    const res = await fetch(`http://localhost:1337/api/categories/`, {
+    const res = await fetch(`${process.env.SERVER_ROUTE}api/categories/`, {
         cache: "no-store",
     });
     if (!res.ok) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@types/node": "20.6.3",
         "@types/react": "18.2.22",
         "@types/react-dom": "18.2.7",
+        "dotenv": "^16.3.1",
         "eslint": "8.49.0",
         "eslint-config-next": "13.5.2",
         "lucide-react": "^0.279.0",
@@ -1010,6 +1011,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@types/node": "20.6.3",
     "@types/react": "18.2.22",
     "@types/react-dom": "18.2.7",
+    "dotenv": "^16.3.1",
     "eslint": "8.49.0",
     "eslint-config-next": "13.5.2",
     "lucide-react": "^0.279.0",


### PR DESCRIPTION
Added server routes to .env file
SERVER_ROUTE can be used for server side code, and NEXT_PUBLIC_SERVER_ROUTE is for client side code.
.env.example file has been created so people can copy paste it and get going
Additionally the code has been updated to utilise dotenv